### PR TITLE
Feat: Add Bolt badge to header

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -40,7 +40,12 @@ const Header = ({ theme, onThemeToggle }) => {
             </div>
           </div>
           
-          <ThemeToggle theme={theme} onToggle={onThemeToggle} />
+          <div className="flex items-center space-x-4">
+            <a href="https://bolt.new" target="_blank" rel="noopener noreferrer">
+              <img src="/src/assets/bolt-badge.png" alt="Bolt Badge" className="w-10 h-10" /> {/* Adjusted size */}
+            </a>
+            <ThemeToggle theme={theme} onToggle={onThemeToggle} />
+          </div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
- Added the Bolt badge to the upper right corner of the header.
- The badge links to https://bolt.new.
- Image asset saved in src/assets/bolt-badge.png.