### PR TITLE
Refactor: Modularize coaching message handler by sessionType

### DIFF
--- a/worker/src/handlers/diagnosticHandler.ts
+++ b/worker/src/handlers/diagnosticHandler.ts
@@ -1,0 +1,29 @@
+import {
+  CoachingMessage,
+  UserProfile,
+  Env,
+  SessionHandler,
+  DiagnosticConfig,
+  // Assuming AIResponse or a more specific type for diagnosticChain result
+} from '../types';
+import { DiagnosticChain } from '../chains/diagnostic';
+
+export const handleDiagnostic: SessionHandler = async (
+  coachingMessage: CoachingMessage,
+  userProfile: UserProfile,
+  env: Env,
+  _executionCtx: ExecutionContext,
+): Promise<any> => { // Replace 'any' with the actual return type of diagnosticChain.assessUser
+  // In a real app, configs might come from a KV store or be more dynamic
+  const diagnosticConfig: DiagnosticConfig = {
+    assessmentFrameworks: ['SDT'],
+    maxQuestions: 1,
+    maxTokens: 500,
+    temperature: 0.3,
+    model: 'gemini-2.5-flash', // Consider making model configurable
+    systemPrompt: '', // Define or load appropriate system prompt
+  };
+
+  const diagnosticChain = new DiagnosticChain(env.GOOGLE_API_KEY, diagnosticConfig);
+  return diagnosticChain.assessUser(coachingMessage, userProfile);
+};

--- a/worker/src/handlers/interventionHandler.ts
+++ b/worker/src/handlers/interventionHandler.ts
@@ -1,0 +1,46 @@
+import {
+  CoachingMessage,
+  UserProfile,
+  Env,
+  SessionHandler,
+  DiagnosticConfig,
+  InterventionConfig,
+  // Assuming AIResponse or a more specific type for chain results
+} from '../types';
+import { DiagnosticChain } from '../chains/diagnostic';
+import { InterventionsChain } from '../chains/interventions';
+
+export const handleIntervention: SessionHandler = async (
+  coachingMessage: CoachingMessage,
+  userProfile: UserProfile,
+  env: Env,
+  _executionCtx: ExecutionContext,
+): Promise<any> => { // Replace 'any' with the actual return type
+  // In a real app, configs might come from a KV store or be more dynamic
+  const diagnosticConfig: DiagnosticConfig = {
+    assessmentFrameworks: ['SDT'],
+    maxQuestions: 1,
+    maxTokens: 500,
+    temperature: 0.3,
+    model: 'gemini-2.5-flash',
+    systemPrompt: '',
+  };
+  const interventionConfig: InterventionConfig = {
+    interventionTypes: ['behavioral', 'cognitive'],
+    personalityFactors: true,
+    maxTokens: 1000,
+    temperature: 0.4,
+    model: 'gemini-2.5-flash',
+    systemPrompt: '',
+  };
+
+  const diagnosticChain = new DiagnosticChain(env.GOOGLE_API_KEY, diagnosticConfig);
+  const interventionsChain = new InterventionsChain(env.GOOGLE_API_KEY, interventionConfig);
+
+  // TODO: Consider if userProfile should be updated with new assessment insights
+  // This was a TODO in the original code. For now, replicating the logic.
+  // If userProfile is mutable and needs update, this handler might need to return it
+  // or the update mechanism needs to be clearly defined.
+  const assessmentData = await diagnosticChain.assessUser(coachingMessage, userProfile);
+  return interventionsChain.prescribeIntervention(coachingMessage, userProfile, assessmentData);
+};

--- a/worker/src/handlers/onboardingDiagnosticHandler.ts
+++ b/worker/src/handlers/onboardingDiagnosticHandler.ts
@@ -1,0 +1,34 @@
+import {
+  CoachingMessage,
+  UserProfile,
+  Env,
+  SessionHandler,
+  SnapshotData,
+} from '../types';
+import { SnapshotChain } from '../chains/snapshot';
+
+export const handleOnboardingDiagnostic: SessionHandler = async (
+  coachingMessage: CoachingMessage,
+  userProfile: UserProfile,
+  env: Env,
+  _executionCtx: ExecutionContext,
+): Promise<{ message: string; snapshotData: SnapshotData }> => {
+  const onboardingAnswers = coachingMessage.context?.onboardingAnswers;
+  if (!onboardingAnswers) {
+    // This case should ideally be caught by validation before calling the handler,
+    // but as a safeguard:
+    throw new Error('Onboarding answers not provided for onboarding_diagnostic session type.');
+  }
+
+  if (!env.USER_SESSIONS_KV) {
+    throw new Error('USER_SESSIONS_KV not configured');
+  }
+
+  const snapshotChain = new SnapshotChain();
+  const snapshotData = await snapshotChain.generateSnapshot(onboardingAnswers, userProfile);
+
+  // Store snapshot data in KV
+  await env.USER_SESSIONS_KV.put(`snapshot_${userProfile.id}`, JSON.stringify(snapshotData));
+
+  return { message: 'Onboarding diagnostic completed and snapshot generated.', snapshotData };
+};

--- a/worker/src/handlers/reflectionHandler.ts
+++ b/worker/src/handlers/reflectionHandler.ts
@@ -1,0 +1,58 @@
+import {
+  CoachingMessage,
+  UserProfile,
+  Env,
+  SessionHandler,
+  InterventionConfig,
+  Microtask, // Assuming Microtask is the type for adaptedMicrotask
+} from '../types';
+import { InterventionsChain } from '../chains/interventions';
+
+export const handleReflection: SessionHandler = async (
+  coachingMessage: CoachingMessage,
+  userProfile: UserProfile,
+  env: Env,
+  _executionCtx: ExecutionContext,
+): Promise<{ message: string; nextAdaptedTask: Microtask }> => {
+  const previousTask = coachingMessage.context?.previousTask;
+  const reflectionId = coachingMessage.context?.reflectionId;
+  const reflectionText = coachingMessage.message; // User's textual reflection
+
+  if (!previousTask || !reflectionId) {
+    // This case should ideally be caught by validation before calling the handler
+    throw new Error('Previous task and reflectionId are required for reflection session type.');
+  }
+
+  if (!env.USER_SESSIONS_KV || !env.GOOGLE_API_KEY) {
+    // Check for GOOGLE_API_KEY as InterventionsChain requires it
+    throw new Error('USER_SESSIONS_KV or GOOGLE_API_KEY not configured');
+  }
+
+  // In a real app, configs might come from a KV store or be more dynamic
+  const interventionConfig: InterventionConfig = {
+    interventionTypes: ['behavioral', 'cognitive'], // Adjust as needed for reflection adaptation
+    personalityFactors: true,
+    maxTokens: 1000, // Adjust as needed
+    temperature: 0.4, // Adjust as needed
+    model: 'gemini-2.5-flash',
+    systemPrompt: '', // Define or load appropriate system prompt for task adaptation
+  };
+
+  const interventionsChain = new InterventionsChain(env.GOOGLE_API_KEY, interventionConfig);
+
+  const adaptedMicrotask = await interventionsChain.generateAdaptedMicrotask(
+    previousTask,
+    reflectionId,
+    reflectionText,
+    userProfile
+  );
+
+  // Storing the adapted microtask to KV
+  await env.USER_SESSIONS_KV.put(`nextAdaptedTask_${userProfile.id}`, JSON.stringify(adaptedMicrotask));
+  console.log(`Stored nextAdaptedTask_${userProfile.id}: ${JSON.stringify(adaptedMicrotask)}`);
+
+  return {
+    message: "Reflection processed and next task generated.",
+    nextAdaptedTask: adaptedMicrotask
+  };
+};

--- a/worker/src/handlers/snapshotGenerationHandler.ts
+++ b/worker/src/handlers/snapshotGenerationHandler.ts
@@ -1,0 +1,25 @@
+import {
+  CoachingMessage,
+  UserProfile,
+  Env,
+  SessionHandler,
+  SnapshotData,
+} from '../types';
+
+export const handleSnapshotGeneration: SessionHandler = async (
+  _coachingMessage: CoachingMessage, // Not directly used, but part of the SessionHandler signature
+  userProfile: UserProfile,
+  env: Env,
+  _executionCtx: ExecutionContext,
+): Promise<SnapshotData> => {
+  if (!env.USER_SESSIONS_KV) {
+    throw new Error('USER_SESSIONS_KV not configured');
+  }
+
+  const snapshotString = await env.USER_SESSIONS_KV.get(`snapshot_${userProfile.id}`);
+  if (!snapshotString) {
+    // Consider a specific error type or code for "not found"
+    throw new Error('Snapshot data not found for user.');
+  }
+  return JSON.parse(snapshotString) as SnapshotData;
+};

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -1,10 +1,296 @@
 import { describe, it, expect } from 'vitest';
 import app from './index';
 
+// Mock environment variables and KV namespaces before importing the app
+// Vitest auto-mocks by convention if __mocks__ folder is present or vi.mock is used.
+// For simplicity here, we'll assume manual or setup file mocking.
+
+// Example: Mocking KV
+const MOCK_KV_STORE = new Map<string, string>();
+
+vi.mock('./types', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // Potentially mock schemas if they cause issues in test env without full setup
+  };
+});
+
+vi.mock('./chains/guardrail', () => {
+  return {
+    GuardrailChain: vi.fn().mockImplementation(() => {
+      return {
+        assessSafety: vi.fn().mockResolvedValue({ shouldProceed: true, response: 'Safe' }),
+      };
+    }),
+  };
+});
+
+// Mock individual handlers
+vi.mock('./handlers/diagnosticHandler', () => ({
+  handleDiagnostic: vi.fn().mockResolvedValue({ type: 'diagnostic', data: 'diagnostic_data' }),
+}));
+vi.mock('./handlers/interventionHandler', () => ({
+  handleIntervention: vi.fn().mockResolvedValue({ type: 'intervention', data: 'intervention_data' }),
+}));
+vi.mock('./handlers/onboardingDiagnosticHandler', () => ({
+  handleOnboardingDiagnostic: vi.fn().mockResolvedValue({ type: 'onboarding_diagnostic', data: 'onboarding_data' }),
+}));
+vi.mock('./handlers/reflectionHandler', () => ({
+  handleReflection: vi.fn().mockResolvedValue({ type: 'reflection', data: 'reflection_data' }),
+}));
+vi.mock('./handlers/snapshotGenerationHandler', () => ({
+  handleSnapshotGeneration: vi.fn().mockResolvedValue({ type: 'snapshot', data: 'snapshot_data' }),
+}));
+
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import app from './index'; // app should be imported after mocks
+import { CoachingMessageSchema, UserProfileSchema } from './types'; // For creating test data
+
 describe('Worker', () => {
+  beforeEach(() => {
+    MOCK_KV_STORE.clear();
+    vi.clearAllMocks(); // Clear mocks before each test
+
+    // Mock env
+    const mockEnv = {
+      USER_SESSIONS_KV: {
+        get: vi.fn((key: string) => Promise.resolve(MOCK_KV_STORE.get(key))),
+        put: vi.fn((key: string, value: string) => {
+          MOCK_KV_STORE.set(key, value);
+          return Promise.resolve();
+        }),
+      },
+      COACHING_HISTORY_KV: {
+        put: vi.fn().mockResolvedValue(undefined),
+      },
+      GOOGLE_API_KEY: 'test-google-api-key',
+      // Add other env vars if your handlers/chains use them
+    };
+
+    // Bind env to app context for tests if Hono supports it this way for testing
+    // This is a conceptual step; actual Hono testing might require `app.fetch(req, env, ctx)`
+    // For now, handlers are mocked, so direct env injection into app might not be strictly needed
+    // if handlers receive env correctly.
+  });
+
   it('should respond to /health', async () => {
     const res = await app.request('/health');
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ success: true, message: 'ok' });
+  });
+
+  describe('/api/coaching/message endpoint', () => {
+    const defaultUserId = 'test-user-123';
+    const defaultSessionId = 'test-session-456';
+
+    const createMockRequest = (body: Record<string, unknown>) => {
+      return new Request('http://localhost/api/coaching/message', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    };
+
+    const mockUserProfile: UserProfile = UserProfileSchema.parse({
+      id: defaultUserId,
+      createdAt: new Date().toISOString(),
+      lastActive: new Date().toISOString(),
+      preferences: {},
+      psychologicalProfile: {},
+    });
+
+    beforeEach(async () => {
+      // Store a default user profile for most tests
+      MOCK_KV_STORE.set(defaultUserId, JSON.stringify(mockUserProfile));
+    });
+
+    it('should return 400 if request body is invalid', async () => {
+      const req = createMockRequest({ invalid_field: "some_value" });
+      // @ts-ignore // Env might not be perfectly typed here for test requests
+      const res = await app.fetch(req, { USER_SESSIONS_KV: MOCK_KV_STORE });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.success).toBe(false);
+      expect(json.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('should return 400 for invalid sessionType', async () => {
+      const body = {
+        userId: defaultUserId,
+        message: "Hello",
+        context: { sessionType: "invalid_session_type" }
+      };
+      const req = createMockRequest(body);
+      // @ts-ignore
+      const res = await app.fetch(req, { USER_SESSIONS_KV: MOCK_KV_STORE });
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error.message).toContain('Invalid session type');
+    });
+
+    it('should call handleDiagnostic for "diagnostic" sessionType', async () => {
+      const diagnosticBody = CoachingMessageSchema.parse({
+        userId: defaultUserId,
+        sessionId: defaultSessionId,
+        message: 'I feel down',
+        context: { sessionType: 'diagnostic' },
+      });
+      const req = createMockRequest(diagnosticBody);
+      const mockEnv = { USER_SESSIONS_KV: MOCK_KV_STORE, GOOGLE_API_KEY: 'test', COACHING_HISTORY_KV: MOCK_KV_STORE };
+      // @ts-ignore
+      const res = await app.fetch(req, mockEnv);
+      expect(res.status).toBe(200);
+      // Check if the mocked handleDiagnostic was called
+      const { handleDiagnostic } = await import('./handlers/diagnosticHandler');
+      expect(handleDiagnostic).toHaveBeenCalled();
+      const json = await res.json();
+      expect(json.data.type).toBe('diagnostic'); // From mock
+    });
+
+    it('should call handleIntervention for "intervention" sessionType', async () => {
+        const interventionBody = CoachingMessageSchema.parse({
+            userId: defaultUserId,
+            sessionId: defaultSessionId,
+            message: 'Suggest something',
+            context: { sessionType: 'intervention' },
+        });
+        const req = createMockRequest(interventionBody);
+        const mockEnv = { USER_SESSIONS_KV: MOCK_KV_STORE, GOOGLE_API_KEY: 'test', COACHING_HISTORY_KV: MOCK_KV_STORE };
+        // @ts-ignore
+        const res = await app.fetch(req, mockEnv);
+        expect(res.status).toBe(200);
+        const { handleIntervention } = await import('./handlers/interventionHandler');
+        expect(handleIntervention).toHaveBeenCalled();
+        const json = await res.json();
+        expect(json.data.type).toBe('intervention');
+    });
+
+    it('should call handleOnboardingDiagnostic for "onboarding_diagnostic" sessionType', async () => {
+      const onboardingBody = CoachingMessageSchema.parse({
+        userId: defaultUserId,
+        message: 'Starting onboarding',
+        context: {
+          sessionType: 'onboarding_diagnostic',
+          onboardingAnswers: {
+            mindset: 'growth', locus: 'internal', regulatory_focus: 'promotion',
+            personality_disorganized: 1, personality_outgoing: 3, personality_moody: 2,
+            final_focus: 'career'
+          }
+        },
+      });
+      const req = createMockRequest(onboardingBody);
+      const mockEnv = { USER_SESSIONS_KV: MOCK_KV_STORE, GOOGLE_API_KEY: 'test' };
+       // @ts-ignore
+      const res = await app.fetch(req, mockEnv);
+      expect(res.status).toBe(200);
+      const { handleOnboardingDiagnostic } = await import('./handlers/onboardingDiagnosticHandler');
+      expect(handleOnboardingDiagnostic).toHaveBeenCalled();
+      const json = await res.json();
+      expect(json.data.type).toBe('onboarding_diagnostic');
+    });
+
+    it('should return 400 if onboardingAnswers are missing for "onboarding_diagnostic"', async () => {
+        const body = {
+            userId: defaultUserId,
+            message: "Hello",
+            context: { sessionType: "onboarding_diagnostic" } // Missing onboardingAnswers
+        };
+        const req = createMockRequest(body);
+        const mockEnv = { USER_SESSIONS_KV: MOCK_KV_STORE, GOOGLE_API_KEY: 'test' };
+        // @ts-ignore
+        const res = await app.fetch(req, mockEnv);
+        expect(res.status).toBe(400);
+        const json = await res.json();
+        expect(json.error.code).toBe('MISSING_ONBOARDING_ANSWERS');
+    });
+
+    it('should call handleReflection for "reflection" sessionType', async () => {
+      const reflectionBody = CoachingMessageSchema.parse({
+        userId: defaultUserId,
+        message: 'The task was easy',
+        context: {
+          sessionType: 'reflection',
+          previousTask: 'do 10 pushups',
+          reflectionId: 'easy'
+        },
+      });
+      const req = createMockRequest(reflectionBody);
+      const mockEnv = { USER_SESSIONS_KV: MOCK_KV_STORE, GOOGLE_API_KEY: 'test', COACHING_HISTORY_KV: MOCK_KV_STORE };
+      // @ts-ignore
+      const res = await app.fetch(req, mockEnv);
+      expect(res.status).toBe(200);
+      const { handleReflection } = await import('./handlers/reflectionHandler');
+      expect(handleReflection).toHaveBeenCalled();
+      const json = await res.json();
+      expect(json.data.type).toBe('reflection');
+    });
+
+    it('should return 400 if previousTask or reflectionId is missing for "reflection"', async () => {
+        const body = {
+            userId: defaultUserId,
+            message: "My reflection",
+            context: { sessionType: "reflection" } // Missing previousTask and reflectionId
+        };
+        const req = createMockRequest(body);
+        const mockEnv = { USER_SESSIONS_KV: MOCK_KV_STORE, GOOGLE_API_KEY: 'test' };
+        // @ts-ignore
+        const res = await app.fetch(req, mockEnv);
+        expect(res.status).toBe(400);
+        const json = await res.json();
+        expect(json.error.code).toBe('MISSING_REFLECTION_DATA');
+    });
+
+    it('should call handleSnapshotGeneration for "snapshot_generation" sessionType', async () => {
+      const snapshotBody = CoachingMessageSchema.parse({
+        userId: defaultUserId,
+        message: 'Get my snapshot', // Message content might not be strictly needed by handler
+        context: { sessionType: 'snapshot_generation' },
+      });
+      // Pre-populate snapshot for this test
+      MOCK_KV_STORE.set(`snapshot_${defaultUserId}`, JSON.stringify({ type: 'snapshot', data: 'snapshot_data' }));
+
+      const req = createMockRequest(snapshotBody);
+      const mockEnv = { USER_SESSIONS_KV: MOCK_KV_STORE, GOOGLE_API_KEY: 'test' };
+      // @ts-ignore
+      const res = await app.fetch(req, mockEnv);
+      expect(res.status).toBe(200);
+      const { handleSnapshotGeneration } = await import('./handlers/snapshotGenerationHandler');
+      expect(handleSnapshotGeneration).toHaveBeenCalled();
+      const json = await res.json();
+      expect(json.data.type).toBe('snapshot');
+    });
+
+    it('should create a new user profile if one does not exist in KV', async () => {
+      const newUserId = 'new-user-789';
+      MOCK_KV_STORE.delete(newUserId); // Ensure no profile exists
+
+      const diagnosticBody = CoachingMessageSchema.parse({
+        userId: newUserId, // Use a new user ID
+        sessionId: defaultSessionId,
+        message: 'I am a new user',
+        context: { sessionType: 'diagnostic' },
+      });
+      const req = createMockRequest(diagnosticBody);
+      const mockEnv = { USER_SESSIONS_KV: MOCK_KV_STORE, GOOGLE_API_KEY: 'test', COACHING_HISTORY_KV: MOCK_KV_STORE };
+
+      // @ts-ignore
+      const res = await app.fetch(req, mockEnv);
+      expect(res.status).toBe(200);
+
+      // Check if a new profile was created and put into KV
+      const profileString = MOCK_KV_STORE.get(newUserId);
+      expect(profileString).toBeDefined();
+      const profile = JSON.parse(profileString!);
+      expect(profile.id).toBe(newUserId);
+
+      const { handleDiagnostic } = await import('./handlers/diagnosticHandler');
+      expect(handleDiagnostic).toHaveBeenCalled();
+    });
+
+    // TODO: Add test for safety assessment failure (Guardrail)
+    // TODO: Add test for KV not configured (for user profile and history)
+    // TODO: Add tests for conversation history saving logic
   });
 });

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -270,3 +270,12 @@ export interface Microtask {
   rationale: string;
   task: string;
 }
+
+// Handler function type
+export type SessionHandler = (
+  coachingMessage: CoachingMessage,
+  userProfile: UserProfile,
+  env: Env,
+  executionCtx: ExecutionContext,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+) => Promise<any>;


### PR DESCRIPTION
- Replaced if/else if block in /api/coaching/message with a handler map.
- Created individual handler functions for each sessionType (onboarding_diagnostic, snapshot_generation, diagnostic, intervention, reflection) in worker/src/handlers/.
- Defined SessionHandler type in worker/src/types.ts.
- Updated imports and removed unused ones.
- Added basic test structure with mocks for the refactored endpoint in worker/src/index.test.ts.